### PR TITLE
Added SafeHandleZeroInvalid

### DIFF
--- a/src/KappaDuck.Quack/Interop/Handles/SafeHandleZeroInvalid.cs
+++ b/src/KappaDuck.Quack/Interop/Handles/SafeHandleZeroInvalid.cs
@@ -1,0 +1,15 @@
+// Copyright (c) KappaDuck. All rights reserved.
+// The source code is licensed under MIT License.
+
+using System.Runtime.InteropServices;
+
+namespace KappaDuck.Quack.Interop.Handles;
+
+/// <summary>
+/// Provides a specialized SafeHandle that is considered invalid when the handle is <see cref="nint.Zero"/>.
+/// </summary>
+/// <param name="ownsHandle"><see langword="true"/> means the handle is owned by this instance and will be released when the instance is disposed.</param>
+internal abstract class SafeHandleZeroInvalid(bool ownsHandle) : SafeHandle(nint.Zero, ownsHandle)
+{
+    public override bool IsInvalid => handle == nint.Zero;
+}


### PR DESCRIPTION
Provides a specialized SafeHandle that is considered invalid when the handle is `nint.Zero`.

Closes #30 